### PR TITLE
Fix typo in YAML 1.1 bool spec

### DIFF
--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -157,7 +157,7 @@
   yaml11: ['bool', 'false()', "false"]
 '!!bool no':
   yaml11: ['bool', 'false()', "false"]
-'!!bool N':
+'!!bool No':
   yaml11: ['bool', 'false()', "false"]
 '!!bool NO':
   yaml11: ['bool', 'false()', "false"]


### PR DESCRIPTION
Fixes a type that was causing a missing case and also resulted in a duplicate test case.